### PR TITLE
Build package with ABI version appended to the end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ TAPI_FLAGS      ?= stubify --no-uuids --filetype=tbd-v2
 
 all: $(TARGET).$(ABI_VERSION).dylib $(TARGET).tbd
 
-deb: $(PACKAGE_DOMAIN)$(TARGET)_$(CURRENT_VERSION)_iphoneos-arm.deb $(PACKAGE_DOMAIN)$(TARGET)-dev_$(CURRENT_VERSION)_iphoneos-arm.deb
+deb: $(PACKAGE_DOMAIN)$(TARGET)$(ABI_VERSION)_$(CURRENT_VERSION)_iphoneos-arm.deb $(PACKAGE_DOMAIN)$(TARGET)-dev_$(CURRENT_VERSION)_iphoneos-arm.deb
 
 $(TARGET).$(ABI_VERSION).dylib: $(SRC)/*.c $(INC)/*.h
 	$(IGCC) $(IGCC_FLAGS) $(DYLIB_FLAGS) -o $@ $(SRC)/*.c
@@ -29,7 +29,7 @@ $(TARGET).$(ABI_VERSION).dylib: $(SRC)/*.c $(INC)/*.h
 $(TARGET).tbd: $(TARGET).$(ABI_VERSION).dylib
 	$(TAPI) $(TAPI_FLAGS) -o $@ $<
 
-$(PACKAGE_DOMAIN)$(TARGET)_$(CURRENT_VERSION)_iphoneos-arm.deb: $(PKG)/bin/control.tar.gz $(PKG)/bin/data.tar.lzma $(PKG)/bin/debian-binary
+$(PACKAGE_DOMAIN)$(TARGET)$(ABI_VERSION)_$(CURRENT_VERSION)_iphoneos-arm.deb: $(PKG)/bin/control.tar.gz $(PKG)/bin/data.tar.lzma $(PKG)/bin/debian-binary
 	( cd "$(PKG)/bin"; ar -cr "../../$@" 'debian-binary' 'control.tar.gz' 'data.tar.lzma'; )
 
 $(PACKAGE_DOMAIN)$(TARGET)-dev_$(CURRENT_VERSION)_iphoneos-arm.deb: $(PKG)/dev/control.tar.gz $(PKG)/dev/data.tar.lzma $(PKG)/dev/debian-binary
@@ -54,7 +54,7 @@ $(PKG)/dev/debian-binary: | $(PKG)/dev
 	echo '2.0' > $@
 
 $(PKG)/bin/control: | $(PKG)/bin
-	( echo 'Package: $(PACKAGE_DOMAIN)$(TARGET)'; \
+	( echo 'Package: $(PACKAGE_DOMAIN)$(TARGET)$(ABI_VERSION)'; \
 	  echo 'Name: libkrw'; \
 	  echo 'Author: Siguza'; \
 	  echo 'Maintainer: Siguza'; \
@@ -68,7 +68,7 @@ $(PKG)/bin/control: | $(PKG)/bin
 
 $(PKG)/dev/control: | $(PKG)/dev
 	( echo 'Package: $(PACKAGE_DOMAIN)$(TARGET)-dev'; \
-	  echo 'Depends: $(PACKAGE_DOMAIN)$(TARGET)'; \
+	  echo 'Depends: $(PACKAGE_DOMAIN)$(TARGET)$(ABI_VERSION)'; \
 	  echo 'Name: libkrw-dev'; \
 	  echo 'Author: Siguza'; \
 	  echo 'Maintainer: Siguza'; \

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See [`include/libkrw.h`](https://github.com/Siguza/libkrw/blob/master/include/li
 3. Don't forget the `task_for_pid-allow` entitlement.
 4. If you're building a deb file, add this to your `control`:  
    ```
-   Depends: libkrw (>= 1.0.0)
+   Depends: libkrw0 (>= 1.0.0)
    ```
 
 ##### For writing your own implementation of libkrw:
@@ -44,10 +44,10 @@ See [`include/libkrw.h`](https://github.com/Siguza/libkrw/blob/master/include/li
 2. Compile with `-Wl,-install_name,/usr/lib/libkrw.0.dylib`.
 3. Add this to the `control` of your deb file:  
    ```
-   Package: your.name.libkrw
-   Provides: libkrw
-   Conflicts: libkrw
-   Replaces: libkrw
+   Package: your.name.libkrw0
+   Provides: libkrw0
+   Conflicts: libkrw0
+   Replaces: libkrw0
    ```
    Please **DO NOT** name your package just `libkrw`!
 


### PR DESCRIPTION
This, as Debian does it, allows for the ABI version of the library to change in the future and keep the old version to still be installable/usable.