### PR TITLE
Don't forget to actually use realloc'd path in case it moved

### DIFF
--- a/src/libkrw.c
+++ b/src/libkrw.c
@@ -84,6 +84,7 @@ static void iterate_plugins(int (*callback)(void *), void **check) {
                     fprintf(stderr, "Fatal Error: unable to realloc\n");
                     continue; // We failed to realloc - try next plugin I guess
                 }
+                path = newpath;
             }
             strcpy(path+strlen("/usr/lib/libkrw/"), plugins[i]->d_name);
             void *plugin = dlopen(path, RTLD_LOCAL|RTLD_LAZY);


### PR DESCRIPTION
The memory address of path could have changed and not been used